### PR TITLE
Prevent upgrading MAX31865 library to 1.2

### DIFF
--- a/firmware/marlin2.0 for Ender3/platformio.ini
+++ b/firmware/marlin2.0 for Ender3/platformio.ini
@@ -31,7 +31,7 @@ lib_deps =
   TMCStepper@<1.0.0
   #SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
   #Adafruit NeoPixel@1.2.5
-  Adafruit_MAX31865=https://github.com/adafruit/Adafruit_MAX31865/archive/master.zip
+  Adafruit MAX31865 library@>=1.1,<1.2
   LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
   Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/0.7.0.zip
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip


### PR DESCRIPTION
Backport https://github.com/MarlinFirmware/Marlin/pull/18089/ to MKS base firmware